### PR TITLE
Update async example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ async def main():
 
 
 if __name__ == "__main__":
+    if sys.platform == 'win32':
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
     asyncio.run(main())
 ```
 


### PR DESCRIPTION
added line
```python
    if sys.platform == 'win32':
        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
```
into the if name == main because without it, async will throw an error.
The code still does not work, but now the error is in the libraries code and not an external Exception